### PR TITLE
feat: MultiKeyDict equality

### DIFF
--- a/src/config/lockfile_entry.py
+++ b/src/config/lockfile_entry.py
@@ -16,10 +16,10 @@ class HashEntry:
     md5: str
 
     def __getitem__(self, name: HashAlg):
-        if isinstance(name, str):
-            return getattr(self, str(name))
+        if isinstance(name, HashAlg):
+            return getattr(self, name.value)
         raise TypeError(
-            f'Expected str for HashEntry attribute, got {type(name)}')
+            f'Expected HashAlg for HashEntry attribute, got {type(name)}')
 
 
 @dataclass_json

--- a/src/config/lockfile_test.py
+++ b/src/config/lockfile_test.py
@@ -5,6 +5,7 @@ import json
 from src.config.lockfile import LOCKFILE_FILENAME, Lockfile
 from src.config.lockfile_entry import HashEntry, LockfileEntry
 from src.lib.asset import Asset
+from src.lib.multikey_dict import MultiKeyDict
 from src.util.enum import AssetType, Platform, Side
 
 
@@ -176,14 +177,9 @@ def test_lockfile_multikey_dict_creation(lockfile_from_path):
     """Tests creating a multikey dict from a lockfile object."""
     lockfile = lockfile_from_path("testdata/test_m3.lock.json")
     multikey_dict = lockfile.create_multikey_dict_for_lockfile()
-    assert multikey_dict.len() == 2
-
-    multikey_dict_keys = multikey_dict.get_multikeys()
-    assert ("test-entry", "sha1-hash", "sha512-hash",
-            "md5-hash") in multikey_dict_keys
-    assert ("test-texture-pack", "sha1-hash-texture", "sha512-hash-texture",
-            "md5-hash-texture") in multikey_dict_keys
-    assert multikey_dict.get("test-entry") == LockfileEntry(
+    ref_dict = MultiKeyDict(4)
+    ref_dict.add(("test-entry", "md5-hash",
+                  "sha1-hash", "sha512-hash",), LockfileEntry(
         name="test-entry",
         hash=HashEntry(
             sha1="sha1-hash",
@@ -202,8 +198,9 @@ def test_lockfile_multikey_dict_creation(lockfile_from_path):
             ],
             cdn_link="test-cdn-link"
         )
-    )
-    assert multikey_dict.get("test-texture-pack") == LockfileEntry(
+    ))
+    ref_dict.add(("test-texture-pack", "md5-hash-texture",
+                  "sha1-hash-texture", "sha512-hash-texture", ), LockfileEntry(
         name="test-texture-pack",
         hash=HashEntry(
             sha1="sha1-hash-texture",
@@ -220,4 +217,5 @@ def test_lockfile_multikey_dict_creation(lockfile_from_path):
             dependencies=[],
             cdn_link="test-cdn-link"
         )
-    )
+    ))
+    assert multikey_dict == ref_dict

--- a/src/lib/multikey_dict.py
+++ b/src/lib/multikey_dict.py
@@ -27,15 +27,15 @@ class MultiKeyDict:
         self.data = {}
 
     def __eq__(self, value):
-        if isinstance(value, MultiKeyDict):
-            if self.len() != value.len():
-                return False
-            if self.num_of_keys != value.num_of_keys:
-                return False
-            if self.keys_to_multikeys != value.keys_to_multikeys:
-                return False
-            return True
-        return False
+        if not isinstance(value, MultiKeyDict):
+            return False
+        if self.len() != value.len():
+            return False
+        if self.num_of_keys != value.num_of_keys:
+            return False
+        if self.keys_to_multikeys != value.keys_to_multikeys:
+            return False
+        return True
 
     def _validate_multikey(self, multikey: tuple):
         """Validates that a given multikey contains the right number of keys.

--- a/src/lib/multikey_dict.py
+++ b/src/lib/multikey_dict.py
@@ -26,6 +26,17 @@ class MultiKeyDict:
         self.keys_to_multikeys = {}
         self.data = {}
 
+    def __eq__(self, value):
+        if isinstance(value, MultiKeyDict):
+            if self.len() != value.len():
+                return False
+            if self.num_of_keys != value.num_of_keys:
+                return False
+            if self.keys_to_multikeys != value.keys_to_multikeys:
+                return False
+            return True
+        return False
+
     def _validate_multikey(self, multikey: tuple):
         """Validates that a given multikey contains the right number of keys.
 

--- a/src/util/hash_test.py
+++ b/src/util/hash_test.py
@@ -2,6 +2,7 @@
 
 
 from src.config.lockfile import HASH_ALGS
+from src.lib.multikey_dict import MultiKeyDict
 from src.util.enum import HashAlg
 from src.util.hash import hash_asset_dir, hash_asset_dir_multi_hash
 
@@ -28,31 +29,25 @@ def test_hash_asset_dir_multi_hash(current_dir, read_json_file):
     ref_hashes = read_json_file(
         current_dir / 'testdata/test_filename_to_hashes.json')
     multikey_dict = hash_asset_dir_multi_hash(asset_path, HASH_ALGS)
-    assert multikey_dict.len() == 3
-
-    multikey_dict_keys = multikey_dict.get_multikeys()
-    assert (
+    ref_dict = MultiKeyDict(4)
+    ref_dict.add((
         "a.jar",
         ref_hashes['md5']['a.jar'],
         ref_hashes['sha1']['a.jar'],
         ref_hashes['sha512']['a.jar'],
 
-    ) in multikey_dict_keys
-
-    assert (
+    ), asset_path / "a.jar")
+    ref_dict.add((
         "b.jar",
         ref_hashes['md5']['b.jar'],
         ref_hashes['sha1']['b.jar'],
         ref_hashes['sha512']['b.jar'],
-    ) in multikey_dict_keys
-
-    assert (
+    ), asset_path / "b.jar")
+    ref_dict.add((
         "c.zip",
         ref_hashes['md5']['c.zip'],
         ref_hashes['sha1']['c.zip'],
         ref_hashes['sha512']['c.zip'],
-    ) in multikey_dict_keys
+    ), asset_path / "c.zip")
 
-    assert multikey_dict.get("a.jar") == asset_path / "a.jar"
-    assert multikey_dict.get("b.jar") == asset_path / "b.jar"
-    assert multikey_dict.get("c.zip") == asset_path / "c.zip"
+    assert multikey_dict == ref_dict


### PR DESCRIPTION
- Enable direct comparison between MultiKeyDicts by defining `__eq__()`
- Fix a bug where `__getitem__()` for HashEntry expects a string instead of a HashAlg
- Update testing to utilize direct comparison between MultKeyDicts 