### PR TITLE
Add syntactic sugar to MultiKeyDict access

### DIFF
--- a/src/lib/multikey_dict.py
+++ b/src/lib/multikey_dict.py
@@ -38,7 +38,7 @@ class MultiKeyDict:
         return True
 
     def __getitem__(self, key: Hashable):
-        """Get data associated with key if it exists, else try treating arg as 
+        """Get data associated with key if it exists, else try treating arg as
         an attribute."""
         if key in self.keys_to_multikeys:
             return self.get(key)

--- a/src/lib/multikey_dict.py
+++ b/src/lib/multikey_dict.py
@@ -37,6 +37,13 @@ class MultiKeyDict:
             return False
         return True
 
+    def __getitem__(self, key: Hashable):
+        """Get data associated with key if it exists, else try treating arg as 
+        an attribute."""
+        if key in self.keys_to_multikeys:
+            return self.get(key)
+        return super().__getattribute__(key)
+
     def _validate_multikey(self, multikey: tuple):
         """Validates that a given multikey contains the right number of keys.
 


### PR DESCRIPTION
- Enable square bracket notation for keys in multikey dicts to follow pattern of a regular dict by overriding `__getitem__()`