### PR TITLE
feat: Implement output string formatter for common output elements

### DIFF
--- a/src/cli/diff.py
+++ b/src/cli/diff.py
@@ -5,6 +5,7 @@ import click
 from src.config.loader import load_config_and_lockfile
 from src.config.lockfile import HASH_ALGS
 from src.util.click import command_with_aliases
+from src.util.formatter import CustomOutputFormatter
 from src.util.hash import hash_asset_dir_multi_hash
 
 
@@ -41,11 +42,20 @@ class Diff:
                     curr_asset_multikey_dict.get_by_multikey(asset_key))
 
         # Display the diff correctly formatted
-        click.echo("=========Asset Diff=========")
-        click.echo("ASSETS MISSING FROM LOCKFILE:")
+        formatter = CustomOutputFormatter()
+        click.echo(formatter.format(
+            '{diff_title:title}', diff_title='Asset Diff'))
+        click.echo(
+            formatter.format(
+                '{missing:header}', missing='Lockfile assets missing'))
         for asset in missing_assets:
-            click.echo(f'- {asset}')
-        click.echo("============================")
-        click.echo("NEW ASSETS FOUND:")
+            click.echo(
+                formatter.format(
+                    '{missing_asset:diff_minus}', diff_minus=asset))
+        click.echo(formatter.format('{separator:separator}', separator=''))
+        click.echo(
+            formatter.format(
+                '{new_assets:header}', new_assets='New assets found'))
         for asset in new_assets:
-            click.echo(f'+ {asset}')
+            click.echo(formatter.format(
+                '{new_asset:diff_plus}', new_asset=asset))

--- a/src/util/formatter.py
+++ b/src/util/formatter.py
@@ -1,0 +1,23 @@
+"""String formatter for CLI output."""
+
+from string import Formatter
+
+MAX_LINE_LENGTH = 80
+
+
+class CustomOutputFormatter(Formatter):
+    """Formats common output components."""
+
+    def format_field(self, value, format_spec):
+        padding = (MAX_LINE_LENGTH - len(str(value))) // 2
+        if format_spec == 'title':
+            return ('=' * padding) + str(value).upper() + ('=' * padding)
+        if format_spec == 'header':
+            return str(value).upper()
+        if format_spec == 'diff_minus':
+            return '- ' + str(value)
+        if format_spec == 'diff_plus':
+            return '+ ' + str(value)
+        if format_spec == 'separator':
+            return '=' * MAX_LINE_LENGTH
+        return super().format_field(value, format_spec)


### PR DESCRIPTION
Sample formatted output:
```
$ python3 m3.py diff                                                          
===================================ASSET DIFF===================================
LOCKFILE ASSETS MISSING
================================================================================
NEW ASSETS FOUND
```