### PR TITLE
Add precommit hooks to prevent committing @pytest.mark.only and 'DO NOT COMMIT'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
             entry: bash -c '! grep -rin --include \*.py "@pytest.mark.only" $(git diff --cached --name-only)'
             language: system
             types: [python]
-            args: [-r, -i, -n]
             pass_filenames: false
             always_run: true
           - id: check-do-not-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,18 @@ repos:
             types: [python]
             pass_filenames: false
             always_run: true
+          - id: prevent-pytest-mark-only
+            name: Avoid committing tests with @pytest.mark.only
+            entry: bash -c '! grep -rin --include \*.py "@pytest.mark.only" $(git diff --cached --name-only)'
+            language: system
+            types: [python]
+            args: [-r, -i, -n]
+            pass_filenames: false
+            always_run: true
+          - id: check-do-not-commit
+            name: Avoid committing "DO NOT COMMIT"
+            entry: bash -c '! grep -rin --exclude=".pre-commit-config.yaml" "DO NOT COMMIT" $(git diff --cached --name-only)'
+            language: system
+            types: [file]
+            pass_filenames: false
+            always_run: true


### PR DESCRIPTION
Add pre-commit hooks that prevent commits containing `@pytest.mark.only` and `DO NOT COMMIT`. Pre-commit hooks will display the offending file and line number on failure.

Addresses a previous issue fixed in https://github.com/omgimanerd/m3/pull/37