### PR TITLE
Fix typing error caused by mismatch in expected format for dependencies of assets

### DIFF
--- a/src/cli/add.py
+++ b/src/cli/add.py
@@ -45,8 +45,7 @@ class Add:
                     installed = install_asset(
                         asset_lf_entry, asset_path)
                     context.lockfile.add_entry(asset_lf_entry)
-                    for i in installed:
-                        click.echo(f'Installed {i}')
+                    click.echo(f'Installed {installed}')
                 except ValueError as error:
                     raise click.ClickException(error)
                 except FileNotFoundError as error:

--- a/src/lib/asset.py
+++ b/src/lib/asset.py
@@ -85,7 +85,7 @@ class Asset:
     asset_type: AssetType
     side: Side
     cdn_link: str
-    dependencies: list[str]
+    dependencies: list
 
     # pylint: disable-next=missing-function-docstring
     def get_asset_identifier(self) -> tuple[Union[str, int], Union[str, int]]:


### PR DESCRIPTION
- Fix incorrect typing declaration for `Asset` dataclass
- Fix incorrect print statement upon asset installation

The `Asset` dataclass had an incorrect typing declaration for the asset dependencies field, where `list[str]` should have been `list[dict]`. However, changing this to `list[dict] = field(default_factory=list)` causes a TypeError because this default argument will come before the non-default attributes of the child `CurseForgeAsset` dataclass.

The dependencies typing will be relaxed to `list` in order to accept empty lists without creating a default argument. This issue should be revisited in the future to find a solution that scopes the type more clearly without causing TypeErrors.