### PR TITLE
Feat/atomic add apply

### DIFF
--- a/src/cli/apply.py
+++ b/src/cli/apply.py
@@ -1,9 +1,15 @@
 """apply subcommand module"""
 
+import os
+import tempfile
+from pathlib import Path
+
 import click
 
 from src.config.loader import load_config_and_lockfile
 from src.config.lockfile import HASH_ALGS
+from src.lib.copy import copy
+from src.lib.overwrite import overwrite_dir
 from src.util.asset_management import (create_entry_queue, install_assets,
                                        uninstall_assets)
 from src.util.enum import AssetStatus
@@ -28,27 +34,36 @@ class Apply:
         if config is None or lockfile is None:
             raise click.ClickException('Not an m3 project')
 
-        for asset_type, path in config.get_asset_paths().items():
-            lockfile_assets_multikey_dict = lockfile.get_assets_by_type(
-                asset_type)
-            curr_asset_multikey_dict = hash_asset_dir_multi_hash(
-                path, HASH_ALGS)
-            install_queue = create_entry_queue(
-                lockfile_assets_multikey_dict, lockfile_assets_multikey_dict.
-                get_multikey_difference(curr_asset_multikey_dict))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for asset_type, path in config.get_asset_paths().items():
+                temp_asset_path = Path(tmpdir) / asset_type.value
+                os.mkdir(temp_asset_path)
+                copy(path, Path(temp_asset_path), ['*'], [])
 
-            results = install_assets(install_queue, path)
+                lockfile_assets_multikey_dict = lockfile.get_assets_by_type(
+                    asset_type)
+                curr_asset_multikey_dict = hash_asset_dir_multi_hash(
+                    temp_asset_path, HASH_ALGS)
+                install_queue = create_entry_queue(
+                    lockfile_assets_multikey_dict,
+                    lockfile_assets_multikey_dict.get_multikey_difference(
+                        curr_asset_multikey_dict))
 
-            for i in results[AssetStatus.INSTALLED]:
-                click.echo(f'Installed {i}')
+                results = install_assets(install_queue, Path(temp_asset_path))
 
-            for ni in results[AssetStatus.ERROR_INSTALL]:
-                click.echo(ni)
+                for i in results[AssetStatus.INSTALLED]:
+                    click.echo(f'Installed {i}')
 
-            if remove:
-                uninstall_queue = create_entry_queue(
-                    curr_asset_multikey_dict, curr_asset_multikey_dict.
-                    get_multikey_difference(lockfile_assets_multikey_dict))
-                uninstall_assets(uninstall_queue, path, click.echo)
+                for ni in results[AssetStatus.ERROR_INSTALL]:
+                    click.echo(ni)
+
+                if remove:
+                    uninstall_queue = create_entry_queue(
+                        curr_asset_multikey_dict, curr_asset_multikey_dict.
+                        get_multikey_difference(lockfile_assets_multikey_dict))
+                    uninstall_assets(
+                        uninstall_queue, temp_asset_path, click.echo)
+            for asset_type, path in config.get_asset_paths().items():
+                overwrite_dir(path, (Path(tmpdir) / asset_type.value))
 
         click.echo('Applied lockfile state to development directory')

--- a/src/cli/apply_test.py
+++ b/src/cli/apply_test.py
@@ -22,11 +22,12 @@ def test_apply(mock_download_file,
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         copy_test_data_directory(ref_path, td)
+        expected_filepath = Path(td) / 'assets/texturepacks/c.zip'
         mock_download_file.side_effect = lambda *args, **kwargs: create_file(
-            Path(td) / 'assets/texturepacks/c.zip', 'Test file c.zip')
-        result = runner.invoke(Apply.apply)
+            expected_filepath, 'Test file c.zip')
+        runner.invoke(Apply.apply)
     mock_download_file.assert_called_once()
-    assert "Installed c.zip" in result.output
+    assert expected_filepath.is_file()
 
 
 @patch('src.config.lockfile.LOCKFILE_FILENAME', 'test_m3.lock.json')
@@ -42,11 +43,13 @@ def test_apply_with_remove(
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         copy_test_data_directory(ref_path, td)
+        expected_filepath = Path(td) / 'assets/texturepacks/c.zip'
         mock_download_file.side_effect = lambda *args, **kwargs: create_file(
-            Path(td) / 'assets/texturepacks/c.zip', 'Test file c.zip')
-        result = runner.invoke(Apply.apply, ['-r'])
+            expected_filepath, 'Test file c.zip')
+        runner.invoke(Apply.apply, ['-r'])
 
     mock_download_file.assert_called_once()
-    assert not os.path.exists(tmp_path / '/assets/mods/b.jar')
-    assert "Installed c.zip" in result.output
-    assert "Uninstalled b.jar" in result.output
+    uninstalled_filepath = tmp_path / '/assets/mods/b.jar'
+    assert not os.path.exists(uninstalled_filepath)
+    assert expected_filepath.is_file()
+    assert not uninstalled_filepath.is_file()

--- a/src/lib/copy.py
+++ b/src/lib/copy.py
@@ -13,9 +13,9 @@ def _is_excluded(path: Path, exclude: list[Path]):
     return False
 
 
-def copy(root: Path, dest: Path, include: list[Path], exclude: list[Path],
+def copy(root: Path, dest: Path, include: list[str], exclude: list[Path],
          callback: Optional[Callable[[str], None]] = None):
-    """Copies all of the include patterns rooted at root into destination,
+    """Recursively copies all of the include patterns rooted at root into destination,
     excluding any files that match the exclusion pattern.
 
     Args:
@@ -28,7 +28,7 @@ def copy(root: Path, dest: Path, include: list[Path], exclude: list[Path],
             is copied, can be used to provide logging or other functionality
     """
     for pattern in include:
-        for path in root.glob(pattern):
+        for path in root.rglob(pattern):
             relative = path.relative_to(root)
             if path.is_dir():
                 continue

--- a/src/lib/overwrite.py
+++ b/src/lib/overwrite.py
@@ -1,0 +1,40 @@
+"""Module to handle overwriting a given directory with contents from a source directory."""
+
+import shutil
+from pathlib import Path
+
+
+def _delete_directory(path: Path):
+    """Deletes the given directory if it exists."""
+    try:
+        shutil.rmtree(path)
+    except FileNotFoundError:
+        raise
+
+
+def overwrite_dir(
+        dest: Path, src: Path):
+    """Overwrites and replaces the contents of the destination directory with
+    the contents from the source directory.
+
+    Args:
+        dest: the directory to overwrite the contents of
+        src: the directory containing the contents to overwrite the dest with
+    """
+    try:
+        _delete_directory(dest)
+        shutil.copytree(src, dest)
+    except shutil.Error as error:
+        err_msg = "Errors occurred during copytree operation:\n"
+        for err_info in error.args[0]:
+            s, d, msg = err_info
+            err_msg += f"Failed to copy '{s}' to '{d}': {msg}\n"
+        raise OSError(err_msg) from error
+    except FileExistsError as error:
+        raise FileExistsError(
+            f"Error: Destination directory '{dest}' already exists") from error
+    except FileNotFoundError as error:
+        raise FileNotFoundError(
+            f"Error: Source directory '{src}' not found") from error
+    except OSError as error:
+        raise


### PR DESCRIPTION
- Implement `overwrite_dir` utility method for overwriting the contents of a given directory
- Update `copy` utility method to run recursively and copy over hidden directories so they don't get lost when copying over for atomic actions
- Make `Add` and `Apply` commands atomic
- Update `Apply` tests to check against the filesystem instead of relying on specific output logging statements