### PR TITLE
Fix/atomic apply add tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,11 +3,14 @@
 import json
 import os
 import shutil
+import tempfile
 from collections import OrderedDict
 from pathlib import Path
 from typing import Callable
 
 import pytest
+
+from src.config.config import Config
 
 # Fixtures defined in modules in this project.
 # pylint: disable-next=invalid-name
@@ -40,6 +43,18 @@ def read_json_file() -> Callable[[Path], dict]:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
     return _read_json_file
+
+
+@pytest.fixture
+def setup_asset_dir(tmp_path) -> Callable[[Path], Path]:
+    """Test fixture that returns a function to set up a default asset directory
+    structure for testing in the given root path and return the path to the root
+    of the structure."""
+    def _setup_asset_dir(config: Config, dest_path: Path = tmp_path):
+        for _, asset_path in config.paths.get().items():
+            os.makedirs(dest_path / asset_path, exist_ok=True)
+        return dest_path
+    return _setup_asset_dir
 
 
 @pytest.fixture
@@ -78,3 +93,11 @@ def load_dir() -> Callable[[Path], OrderedDict]:
                 continue
         return d
     return _load_dir
+
+
+@pytest.fixture
+def create_tmpdir() -> Callable[[Path], Path]:
+    """Test fixture that creates a temporary directory with the specified path."""
+    def _create_tmpdir(dir_: Path) -> Path:
+        return os.makedirs(dir_, exist_ok=True)
+    return _create_tmpdir

--- a/src/api/wrappers/cf_wrapper.py
+++ b/src/api/wrappers/cf_wrapper.py
@@ -119,4 +119,15 @@ class CurseForgeWrapper:  # pylint: disable=too-few-public-methods
             body={
                 "fileIds": file_ids,
             },
-            unpacker=lambda json: CFGetFilesResponse(**json))
+            unpacker=lambda json: CFGetFilesResponse(**json)).data
+
+    def get_asset_file(self, file_id) -> CFFile:
+        """Return a CFFile object containing file metadata.
+
+        Args:
+            file_id: The CurseForge file ID to query
+
+        Returns:
+            A CFFile object.
+        """
+        return self.get_asset_files([file_id])[0]

--- a/src/cli/add_test.py
+++ b/src/cli/add_test.py
@@ -23,9 +23,10 @@ class AddTest:
     @patch.object(CurseForgeWrapper, 'get_asset_files')
     @patch('src.util.asset_management.download_file')
     def test_add(
-            self, mock_download_file, mock_get_asset_files, mock_get_mod,
-            mock_create_lockfile_entry_from_resp_obj, copy_test_data_directory,
-            current_dir, tmp_path, create_file, read_json_file):
+            self, mock_download_file, mock_get_asset_files,
+            mock_get_mod, mock_create_lockfile_entry_from_resp_obj,
+            config_from_path, copy_test_data_directory, current_dir, tmp_path,
+            setup_asset_dir, create_tmpdir, create_file, read_json_file):
         """Tests that the add command installs the given asset to the project."""
         ref_path = current_dir / 'testdata/'
         runner = CliRunner()
@@ -49,16 +50,32 @@ class AddTest:
             hash=mock_asset_hashes, platform=mock_asset.platform,
             asset_type=mock_asset.asset_type, asset=mock_asset)
 
-        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-            copy_test_data_directory(ref_path, td)
-            expected_filepath = Path(td) / 'assets/mods/d.jar'
+        mock_config = config_from_path(ref_path / 'test_m3.json')
+        asset_paths = mock_config.paths.get()
 
-            def _mock_download_file(*args, **kwargs):
-                create_file(expected_filepath, 'Test file d.jar')
-            mock_download_file.side_effect = _mock_download_file
-            runner.invoke(Add.add, [str(FILE_ID_FOR_TEST)])
-            mock_download_file.assert_called_once()
-            assert expected_filepath.is_file()
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            copy_test_data_directory(
+                ref_path, Path(td))
+            setup_asset_dir(mock_config, Path(td))
+
+            expected_filepath = Path(td) / asset_paths[AssetType.MOD] / 'd.jar'
+            tmp_dir_path = Path(td) / 'temp'
+            tmp_expected_filepath = tmp_dir_path / \
+                asset_paths[AssetType.MOD] / 'd.jar'
+            create_tmpdir(tmp_dir_path)
+
+            with patch('tempfile.TemporaryDirectory') as mock_tmpdir:
+                mock_tmpdir_context = MagicMock()
+                mock_tmpdir_context.__enter__.return_value = tmp_dir_path
+                mock_tmpdir.return_value = mock_tmpdir_context
+
+                def _mock_download_file(*args, **kwargs):
+                    create_file(tmp_expected_filepath, 'Test file d.jar')
+                mock_download_file.side_effect = _mock_download_file
+                result = runner.invoke(Add.add, [str(FILE_ID_FOR_TEST)])
+                mock_download_file.assert_called_once()
+                assert expected_filepath.is_file()
+                assert result.exit_code == 0
 
     @patch('src.util.asset_management.download_file')
     def test_add_invalid_file_id_format(
@@ -72,7 +89,8 @@ class AddTest:
         with runner.isolated_filesystem(temp_dir=tmp_path) as td:
             copy_test_data_directory(ref_path, td)
             original_dir_contents = load_dir(Path(td))
-            runner.invoke(Add.add, ['abc'])
+            result = runner.invoke(Add.add, ['abc'])
             new_dir_contents = load_dir(Path(td))
             assert original_dir_contents == new_dir_contents
             mock_download_file.assert_not_called()
+            assert result.exit_code == 0

--- a/src/cli/apply_test.py
+++ b/src/cli/apply_test.py
@@ -2,54 +2,91 @@
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
 from src.cli.apply import Apply
+from src.util.enum import AssetType
 
 
 @patch('src.config.lockfile.LOCKFILE_FILENAME', 'test_m3.lock.json')
 @patch('src.config.config.CONFIG_FILENAME', 'test_m3.json')
-@patch('src.util.asset_management.download_file')
-def test_apply(mock_download_file,
-               copy_test_data_directory, current_dir, tmp_path,
-               create_file):
-    """Tests that the apply command applies the lockfile's state to the project
-    assets."""
-    ref_path = current_dir / 'testdata/'
-    runner = CliRunner()
+class ApplyTest:
+    @patch('src.util.asset_management.download_file')
+    def test_apply(self, mock_download_file, copy_test_data_directory,
+                   setup_asset_dir, current_dir, tmp_path, config_from_path,
+                   create_tmpdir, create_file):
+        """Tests that the apply command applies the lockfile's state to the project
+        assets."""
+        ref_path = current_dir / 'testdata/'
+        runner = CliRunner()
 
-    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-        copy_test_data_directory(ref_path, td)
-        expected_filepath = Path(td) / 'assets/texturepacks/c.zip'
-        mock_download_file.side_effect = lambda *args, **kwargs: create_file(
-            expected_filepath, 'Test file c.zip')
-        runner.invoke(Apply.apply)
-    mock_download_file.assert_called_once()
-    assert expected_filepath.is_file()
+        mock_config = config_from_path(ref_path / 'test_m3.json')
+        asset_paths = mock_config.paths.get()
 
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            copy_test_data_directory(ref_path, td)
+            setup_asset_dir(mock_config, Path(td))
 
-@patch('src.config.lockfile.LOCKFILE_FILENAME', 'test_m3.lock.json')
-@patch('src.config.config.CONFIG_FILENAME', 'test_m3.json')
-@patch('src.util.asset_management.download_file')
-def test_apply_with_remove(
-        mock_download_file, copy_test_data_directory, current_dir, tmp_path,
-        create_file):
-    """Tests that the apply command applies the lockfile's state to the project
-    assets and removes assets that are not in the lockfile."""
-    ref_path = current_dir / 'testdata/'
-    runner = CliRunner(echo_stdin=True)
+            expected_filepath = Path(
+                td) / asset_paths[AssetType.TEXTURE_PACK] / 'c.zip'
+            tmp_dir_path = Path(td) / 'temp'
+            tmp_expected_filepath = tmp_dir_path / \
+                asset_paths[AssetType.TEXTURE_PACK] / 'c.zip'
+            create_tmpdir(tmp_dir_path)
 
-    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-        copy_test_data_directory(ref_path, td)
-        expected_filepath = Path(td) / 'assets/texturepacks/c.zip'
-        mock_download_file.side_effect = lambda *args, **kwargs: create_file(
-            expected_filepath, 'Test file c.zip')
-        runner.invoke(Apply.apply, ['-r'])
+            with patch('tempfile.TemporaryDirectory') as mock_tmpdir:
+                mock_tmpdir_context = MagicMock()
+                mock_tmpdir_context.__enter__.return_value = tmp_dir_path
+                mock_tmpdir.return_value = mock_tmpdir_context
 
-    mock_download_file.assert_called_once()
-    uninstalled_filepath = tmp_path / '/assets/mods/b.jar'
-    assert not os.path.exists(uninstalled_filepath)
-    assert expected_filepath.is_file()
-    assert not uninstalled_filepath.is_file()
+                def _mock_download_file(*args, **kwargs):
+                    create_file(
+                        tmp_expected_filepath, 'Test file c.zip')
+                mock_download_file.side_effect = _mock_download_file
+                result = runner.invoke(Apply.apply)
+        mock_download_file.assert_called_once()
+        assert expected_filepath.is_file()
+        assert result.exit_code == 0
+
+    @patch('src.util.asset_management.download_file')
+    def test_apply_with_remove(
+            self, mock_download_file, copy_test_data_directory, current_dir,
+            config_from_path, setup_asset_dir, create_tmpdir, tmp_path,
+            create_file):
+        """Tests that the apply command applies the lockfile's state to the project
+        assets and removes assets that are not in the lockfile."""
+        ref_path = current_dir / 'testdata/'
+        runner = CliRunner(echo_stdin=True)
+
+        mock_config = config_from_path(ref_path / 'test_m3.json')
+        asset_paths = mock_config.paths.get()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            copy_test_data_directory(ref_path, td)
+            setup_asset_dir(mock_config, Path(td))
+
+            expected_filepath = Path(
+                td) / asset_paths[AssetType.TEXTURE_PACK] / 'c.zip'
+            tmp_dir_path = Path(td) / 'temp'
+            tmp_expected_filepath = tmp_dir_path / \
+                asset_paths[AssetType.TEXTURE_PACK] / 'c.zip'
+            create_tmpdir(tmp_dir_path)
+
+            with patch('tempfile.TemporaryDirectory') as mock_tmpdir:
+                mock_tmpdir_context = MagicMock()
+                mock_tmpdir_context.__enter__.return_value = tmp_dir_path
+                mock_tmpdir.return_value = mock_tmpdir_context
+
+                def _mock_download_file(*args, **kwargs):
+                    create_file(
+                        tmp_expected_filepath, 'Test file c.zip')
+                mock_download_file.side_effect = _mock_download_file
+                result = runner.invoke(Apply.apply, ['-r'])
+        mock_download_file.assert_called_once()
+        uninstalled_filepath = tmp_path / '/assets/mods/b.jar'
+        assert not os.path.exists(uninstalled_filepath)
+        assert expected_filepath.is_file()
+        assert not uninstalled_filepath.is_file()
+        assert result.exit_code == 0

--- a/src/cli/apply_test.py
+++ b/src/cli/apply_test.py
@@ -29,18 +29,25 @@ class ApplyTest:
             copy_test_data_directory(ref_path, td)
             setup_asset_dir(mock_config, Path(td))
 
+            # Expected filepath of the asset in the real filesystem
             expected_filepath = Path(
                 td) / asset_paths[AssetType.TEXTURE_PACK] / 'c.zip'
             tmp_dir_path = Path(td) / 'temp'
+            # Expected filepath of the asset in the temp filesystem
             tmp_expected_filepath = tmp_dir_path / \
                 asset_paths[AssetType.TEXTURE_PACK] / 'c.zip'
             create_tmpdir(tmp_dir_path)
 
+            # Patch creation of the temp filesystem to make the root of the
+            # temp filesystem predictable and match the path we expect
             with patch('tempfile.TemporaryDirectory') as mock_tmpdir:
                 mock_tmpdir_context = MagicMock()
                 mock_tmpdir_context.__enter__.return_value = tmp_dir_path
                 mock_tmpdir.return_value = mock_tmpdir_context
 
+                # side_effect requires a callable but we need to set the args
+                # of this side_effect here in the test.
+                # Use wrapper function to construct a callable with the args.
                 def _mock_download_file(*args, **kwargs):
                     create_file(
                         tmp_expected_filepath, 'Test file c.zip')
@@ -48,7 +55,7 @@ class ApplyTest:
                 result = runner.invoke(Apply.apply)
         mock_download_file.assert_called_once()
         assert expected_filepath.is_file()
-        assert result.exit_code == 0
+        assert result.exit_code == 0  # Prevents silent failures of test
 
     @patch('src.util.asset_management.download_file')
     def test_apply_with_remove(
@@ -67,18 +74,25 @@ class ApplyTest:
             copy_test_data_directory(ref_path, td)
             setup_asset_dir(mock_config, Path(td))
 
+            # Expected filepath of the asset in the real filesystem
             expected_filepath = Path(
                 td) / asset_paths[AssetType.TEXTURE_PACK] / 'c.zip'
             tmp_dir_path = Path(td) / 'temp'
+            # Expected filepath of the asset in the temp filesystem
             tmp_expected_filepath = tmp_dir_path / \
                 asset_paths[AssetType.TEXTURE_PACK] / 'c.zip'
             create_tmpdir(tmp_dir_path)
 
+            # Patch creation of the temp filesystem to make the root of the
+            # temp filesystem predictable and match the path we expect
             with patch('tempfile.TemporaryDirectory') as mock_tmpdir:
                 mock_tmpdir_context = MagicMock()
                 mock_tmpdir_context.__enter__.return_value = tmp_dir_path
                 mock_tmpdir.return_value = mock_tmpdir_context
 
+                # side_effect requires a callable but we need to set the args
+                # of this side_effect here in the test.
+                # Use wrapper function to construct a callable with the args.
                 def _mock_download_file(*args, **kwargs):
                     create_file(
                         tmp_expected_filepath, 'Test file c.zip')
@@ -89,4 +103,4 @@ class ApplyTest:
         assert not os.path.exists(uninstalled_filepath)
         assert expected_filepath.is_file()
         assert not uninstalled_filepath.is_file()
-        assert result.exit_code == 0
+        assert result.exit_code == 0  # Prevents silent failures of test

--- a/src/util/asset_management.py
+++ b/src/util/asset_management.py
@@ -9,7 +9,6 @@ from click import ClickException
 
 from src.config.lockfile_entry import LockfileEntry
 from src.lib.multikey_dict import MultiKeyDict
-from src.util.enum import AssetStatus
 from src.util.web import download_file
 
 
@@ -45,16 +44,16 @@ def install_asset(
 
 def install_assets(
         lockfile_entries: list[LockfileEntry],
-        asset_path: Path) -> dict[str, list[str]]:
+        asset_path: Path) -> list[str]:
     """Given a list of assets to install, installs the assets to the asset
     path."""
-    result = {AssetStatus.INSTALLED: [], AssetStatus.ERROR_INSTALL: []}
+    result = []
     for entry in lockfile_entries:
         try:
-            result[AssetStatus.INSTALLED].append(
+            result.append(
                 install_asset(entry, asset_path))
         except (requests.HTTPError, ValueError) as error:
-            result[AssetStatus.ERROR_INSTALL].append(str(error))
+            raise error
     return result
 
 

--- a/src/util/enum.py
+++ b/src/util/enum.py
@@ -35,9 +35,3 @@ class HashAlg(Enum):
     SHA256 = 'sha256'
     SHA512 = 'sha512'
     MD5 = 'md5'
-
-
-class AssetStatus(Enum):
-    """Asset status indicating its state in the current project."""
-    INSTALLED = 'installed'
-    ERROR_INSTALL = 'error_install'


### PR DESCRIPTION
Normalize asset path building contracts and fix Add and Apply tests to pass with atomic operation implementation.
- Use config asset paths as source of truth
- Implement test fixture to set up asset directory structure based on config paths
- Update Add and Apply commands to mimic asset directory structure in temp filesystem
- Update Add and Apply tests to build paths based off of config
- Put Apply tests in a class
- Fix bug where Add and Apply tests were failing silently by checking exit code on invoked command
- Clean up unused enums for tracking asset installation status. Not needed because Add and Apply operations are now atomic, so success and error output is never simultaneously handled.
- Make helper function for unpacking CFFile object from API response
- Fix returned object of `get_asset_files` to match documented return type
- Add documentation to clarify tmp filesystem decisions and implementation