### PR TITLE
Implement the remove command

### DIFF
--- a/src/api/dataclasses/cf_response_objects.py
+++ b/src/api/dataclasses/cf_response_objects.py
@@ -5,9 +5,11 @@ from typing import Optional, Union
 
 from pydantic.dataclasses import dataclass
 
+from src.util.enum import HashAlg
+
 CF_HASH_ALG_MAP = {
-    1: 'sha1',
-    2: 'md5'
+    1: HashAlg.SHA1.value,
+    2: HashAlg.MD5.value
 }
 
 

--- a/src/cli/add.py
+++ b/src/cli/add.py
@@ -19,7 +19,7 @@ from src.util.click import command_with_aliases
 INVALID_FILE_ID_ERROR_MSG = 'Not a valid identifier. Currently only support CurseForge modpacks'
 
 
-# pylint: disable-next=too-few-public-methods, missing-class-docstring
+# pylint: disable-next=missing-class-docstring
 class Add:
     @command_with_aliases('a', 'install', 'i', no_args_is_help=True,
                           short_help='Installs assets into the project.')

--- a/src/cli/apply.py
+++ b/src/cli/apply.py
@@ -32,7 +32,6 @@ class Apply:
 
         if config is None or lockfile is None:
             raise click.ClickException('Not an m3 project')
-
         # Use a temp filesystem and make all changes in the temp fs so that if
         # any errors occur, it does not impact the real filesystem.
         # Makes this command's operation atomic.
@@ -49,7 +48,7 @@ class Apply:
                     temp_asset_path, HASH_ALGS)
                 install_queue = create_entry_queue(
                     lockfile_assets_multikey_dict,
-                    lockfile_assets_multikey_dict.get_multikey_difference(
+                    lockfile_assets_multikey_dict.get_multikey_difference_asymmetric(
                         curr_asset_multikey_dict))
 
                 install_assets(install_queue, temp_asset_path)
@@ -60,9 +59,13 @@ class Apply:
                 if remove:
                     uninstall_queue = create_entry_queue(
                         curr_asset_multikey_dict, curr_asset_multikey_dict.
-                        get_multikey_difference(lockfile_assets_multikey_dict))
+                        get_multikey_difference_asymmetric(
+                            lockfile_assets_multikey_dict))
                     uninstall_assets(
-                        uninstall_queue, temp_asset_path, click.echo)
+                        uninstall_queue, temp_asset_path)
+                    for i in uninstall_queue:
+                        # i will always be a file name from a Path object
+                        click.echo(f'Uninstalled {i}')
             for asset_type, path in config.get_asset_paths().items():
                 # Overwrite the contents of the real fs with the updated
                 # contents of the temp fs

--- a/src/cli/diff.py
+++ b/src/cli/diff.py
@@ -24,14 +24,14 @@ def evaluate_diff(
         curr_asset_multikey_dict = hash_asset_dir_multi_hash(
             path, HASH_ALGS)
 
-        missing_asset_set = lockfile_assets_multikey_dict.get_multikey_difference(
+        missing_asset_set = lockfile_assets_multikey_dict.get_multikey_difference_asymmetric(
             curr_asset_multikey_dict)
-        new_asset_set = curr_asset_multikey_dict.get_multikey_difference(
+        new_asset_set = curr_asset_multikey_dict.get_multikey_difference_asymmetric(
             lockfile_assets_multikey_dict)
 
         for asset_key in missing_asset_set:
             missing_assets.append(
-                lockfile_assets_multikey_dict.get_by_multikey(asset_key).file_name)
+                lockfile_assets_multikey_dict.get_by_multikey(asset_key).name)
 
         for asset_key in new_asset_set:
             new_assets.append(

--- a/src/cli/diff_test.py
+++ b/src/cli/diff_test.py
@@ -9,5 +9,5 @@ def test_diff(config_from_path, lockfile_from_path, current_dir):
     config = config_from_path('testdata/test_m3.json')
     lockfile = lockfile_from_path('testdata/test_m3.lock.json')
     missing_assets, new_assets = evaluate_diff(config, lockfile)
-    assert missing_assets == ['c.zip']
+    assert missing_assets == ['c-zip']
     assert new_assets == [current_dir / 'testdata/assets/mods/b.jar']

--- a/src/cli/remove.py
+++ b/src/cli/remove.py
@@ -1,14 +1,72 @@
-"""uninstall subcommand"""
+"""uninstall subcommand module"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
 
 import click
 
+from src.lib.copy import copy
+from src.lib.lockfile_context_manager import M3ContextManager
+from src.lib.overwrite import overwrite_dir
+from src.util.asset_management import uninstall_asset
 from src.util.click import command_with_aliases
 
+INVALID_ASSET_ID_ERROR_MSG = 'Not a valid identifier. Use the m3 internal identifier.'
 
-# pylint: disable-next=too-few-public-methods, missing-class-docstring
+
+# pylint: disable-next=missing-class-docstring
 class Remove:
-    @command_with_aliases('rm', 'uninstall', no_args_is_help=True)
+    @command_with_aliases('rm', 'uninstall', no_args_is_help=True,
+                          short_help='Removes asset from the project.')
     @click.argument('identifier')
     @staticmethod
     def remove(identifier):
-        """Removes the specified asset from your file system and lockfile."""
+        """Removes the specified asset from your file system and lockfile.
+
+        Uses m3's internal identifier to reference the asset to remove.
+        """
+        with M3ContextManager() as context:
+            if context.config is None or context.lockfile is None:
+                raise click.ClickException('Not an m3 project')
+
+            try:
+                multikey_dict = context.lockfile.create_multikey_dict_for_lockfile()
+                if not multikey_dict.is_existing_key(identifier):
+                    click.echo(INVALID_ASSET_ID_ERROR_MSG)
+                    return
+
+                asset_to_remove = multikey_dict.get(identifier)
+                # Use config.get_asset_paths() to get absolute paths
+                asset_path = context.config.get_asset_paths()[
+                    asset_to_remove.asset_type]
+
+                # Use a temp filesystem and make all changes in the temp fs so that if
+                # any errors occur, it does not impact the real filesystem.
+                # Makes this command's operation atomic.
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    # Use config.paths.get() to get relative asset path
+                    temp_asset_path = Path(
+                        tmpdir) / context.config.paths.get()[asset_to_remove.asset_type]
+                    # Create asset dir structure matching real fs in temp fs
+                    os.makedirs(temp_asset_path, exist_ok=True)
+                    copy(
+                        asset_path, Path(temp_asset_path),
+                        include=['*'], exclude=[])
+                    uninstalled = uninstall_asset(
+                        asset_to_remove, temp_asset_path)
+
+                    overwrite_dir(asset_path, temp_asset_path)
+                context.lockfile.remove_entry(asset_to_remove)
+                click.echo(f'Uninstalled {uninstalled}')
+            except ValueError as error:
+                raise click.ClickException(error)
+            except FileNotFoundError as error:
+                raise click.ClickException(
+                    'File not found: ' +
+                    str(error))
+            except (shutil.Error, FileExistsError, OSError) as error:
+                raise click.ClickException(
+                    'An error occurred when attempting to copy project ' +
+                    'state changes: ' + str(error))

--- a/src/cli/remove_test.py
+++ b/src/cli/remove_test.py
@@ -1,0 +1,68 @@
+"""Integration and function testing for remove.py"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from src.cli.remove import Remove
+from src.util.enum import AssetType
+
+ASSET_ID_TO_REMOVE = 'a-jar'
+INVALID_ASSET_ID = 'not-an-asset123'
+
+
+@patch('src.config.lockfile.LOCKFILE_FILENAME', "test_m3.lock.json")
+@patch('src.config.config.CONFIG_FILENAME', "test_m3.json")
+class RemoveTest:
+    def test_remove(
+            self, current_dir, config_from_path, tmp_path,
+            copy_test_data_directory, setup_asset_dir, create_tmpdir):
+        """Tests that the remove command uninstalls the given asset from the
+        project."""
+        ref_path = current_dir / 'testdata/'
+        runner = CliRunner()
+
+        mock_config = config_from_path(ref_path / 'test_m3.json')
+        asset_paths = mock_config.paths.get()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            copy_test_data_directory(
+                ref_path, Path(td))
+            setup_asset_dir(mock_config, Path(td))
+
+            # Expected filepath of the removed asset in the real filesystem
+            removed_filepath = Path(td) / asset_paths[AssetType.MOD] / 'a.jar'
+            tmp_dir_path = Path(td) / 'temp'
+            create_tmpdir(tmp_dir_path)
+
+            # Patch creation of the temp filesystem to make the root of the
+            # temp filesystem predictable and match the path we expect
+            with patch('tempfile.TemporaryDirectory') as mock_tmpdir:
+                mock_tmpdir_context = MagicMock()
+                mock_tmpdir_context.__enter__.return_value = tmp_dir_path
+                mock_tmpdir.return_value = mock_tmpdir_context
+
+                result = runner.invoke(Remove.remove, [ASSET_ID_TO_REMOVE])
+                assert not removed_filepath.is_file()
+                assert result.exit_code == 0  # Prevents silent failures of test
+
+    @patch('src.cli.remove.uninstall_asset')
+    def test_remove_invalid_id(
+        self, mock_uninstall_asset, current_dir,
+            tmp_path, copy_test_data_directory, load_dir):
+        """Tests that the remove command gracefully handles invalid asset
+        IDs."""
+        ref_path = current_dir / 'testdata/'
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            copy_test_data_directory(
+                ref_path, Path(td)
+            )
+            original_dir_contents = load_dir(Path(td))
+            result = runner.invoke(Remove.remove, [INVALID_ASSET_ID])
+            new_dir_contents = load_dir(Path(td))
+            assert original_dir_contents == new_dir_contents
+            mock_uninstall_asset.assert_not_called()
+            assert result.exit_code == 0  # Prevents silent failures of test

--- a/src/config/lockfile.py
+++ b/src/config/lockfile.py
@@ -10,7 +10,7 @@ from typing import Optional, Self, Union
 from click.exceptions import ClickException
 from pydantic.dataclasses import dataclass
 
-from src.config.lockfile_entry import HashEntry, LockfileEntry
+from src.config.lockfile_entry import LockfileEntry
 from src.lib.dataclasses import PathField, dataclass_json
 from src.lib.multikey_dict import MultiKeyDict
 from src.util.dicts import reindex
@@ -77,20 +77,20 @@ class Lockfile:
         If the object exists, updates the existing entry in the lockfile with a
         new LockfileEntry object.
         """
-        self.entries[entry.file_name] = entry
+        self.entries[entry.name] = entry
 
     def remove_entry(self, entry: LockfileEntry):
         """Removes a given entry from the lockfile object.
 
         Returns the removed entry, or None if entry was not found.
         """
-        if self.entries.get(entry.file_name) is not None:
-            return self.entries.pop(entry.file_name)
+        if self.entries.get(entry.name) is not None:
+            return self.entries.pop(entry.name)
         return None
 
     def get_entry(self, entry: LockfileEntry):
         """Gets a specified entry from the lockfile object."""
-        return self.entries.get(entry.file_name)
+        return self.entries.get(entry.name)
 
     def reindex_lockfile_entries(
             self, entries: list[LockfileEntry], f_new_key: Callable
@@ -127,7 +127,7 @@ class Lockfile:
         multikey_dict = MultiKeyDict(len(HASH_ALGS) + 1)
         for entry in self.entries.values():
             if entry.asset_type == asset_type:
-                keys = [entry.file_name]
+                keys = [entry.name]
                 for alg in sorted(HASH_ALGS, key=lambda member: member.value):
                     try:
                         keys.append(entry.hash[alg])
@@ -153,7 +153,7 @@ class Lockfile:
         """
         multikey_dict = MultiKeyDict(len(HASH_ALGS) + 1)
         for entry in self.entries.values():
-            keys = [entry.file_name]
+            keys = [entry.name]
             for alg in sorted(HASH_ALGS, key=lambda member: member.value):
                 try:
                     keys.append(entry.hash[alg])

--- a/src/config/lockfile_entry.py
+++ b/src/config/lockfile_entry.py
@@ -85,7 +85,6 @@ class LockfileEntry:
     """Class for defining lockfile entries."""
     name: str   # internal ID
     display_name: str
-    # TODO: Decide if multikey dicts should be keyed on internal ID or file_name
     file_name: str
     # TODO: Consider redesigning hash/HashEntry into something simpler
     hash: HashEntry

--- a/src/lib/multikey_dict.py
+++ b/src/lib/multikey_dict.py
@@ -132,8 +132,27 @@ class MultiKeyDict:
 
     def get_multikey_difference(self, multikey_dict: Self):
         """Returns the set difference of self's multikeys and the given multikey
-        dict's multikeys.
+        dict's multikeys. The multikeys of both dicts must be symmetric.
         """
         base_dict_set = set(self.get_multikeys())
         comparison_dict_set = set(multikey_dict.get_multikeys())
         return base_dict_set.difference(comparison_dict_set)
+
+    def partial_multikey_in_dict(self, multikey: tuple) -> bool:
+        """Returns True if any key in the given multikey exists in this multikey
+        dict. Returns False otherwise."""
+        for key in multikey:
+            if self.is_existing_key(key):
+                return True
+        return False
+
+    def get_multikey_difference_asymmetric(self, multikey_dict: Self):
+        """Returns the set difference of self's multikeys and given multikey
+        dict's multikeys, where multikeys are asymmetric. A multikey exists in
+        both dicts if any one of its keys exists in a multikey in the other
+        dict."""
+        missing_keys = set()
+        for multikey in self.get_multikeys():
+            if not multikey_dict.partial_multikey_in_dict(multikey):
+                missing_keys.add(multikey)
+        return missing_keys

--- a/src/util/asset_management.py
+++ b/src/util/asset_management.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Callable, Union
+from typing import Union
 
 import requests
 from click import ClickException
@@ -59,25 +59,26 @@ def install_assets(
 
 def uninstall_asset(
         lockfile_entry: Union[LockfileEntry, Path],
-        asset_path: Path, echo: Callable) -> str:
-    """Uninstalls the given asset located at the given path."""
+        asset_path: Path) -> str:
+    """Uninstalls the given asset located at the given path and returns the name
+    of the uninstalled asset."""
     if isinstance(lockfile_entry, LockfileEntry):
         file_path = asset_path / lockfile_entry.file_name
         if os.path.exists(file_path):
             os.remove(file_path)
-            echo(f'Uninstalled {lockfile_entry.display_name}')
         return lockfile_entry.display_name
 
     if os.path.exists(lockfile_entry):
         os.remove(lockfile_entry)
-        echo(f'Uninstalled {lockfile_entry.name}')
         return lockfile_entry.name
 
 
 def uninstall_assets(
         lockfile_entries: list[LockfileEntry],
-        asset_path: Path, echo: Callable):
+        asset_path: Path) -> list[str]:
     """Given a list of assets to uninstall, removes the assets from the asset
-    path."""
+    path and returns a list of asset names that were uninstalled."""
+    result = []
     for entry in lockfile_entries:
-        uninstall_asset(entry, asset_path, echo)
+        result.append(uninstall_asset(entry, asset_path))
+    return result


### PR DESCRIPTION
- Implement comparison method for multikeys that have overlapping keys but are not identical (asymmetric multikey comparison)
- Change multikeys to utilize m3 internal IDs as keys where available, otherwise use filename
- Update methods to use asymmetric multikey comparison
- Implement remove command
- Implement tests for remove command
- Update hash algorithm mapping for CurseForge to use HashAlg enums to reference algorithms for consistency
- Clean up unnecessary pylint ignore rules